### PR TITLE
Add dream recording screen and localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-# Welcome to your Expo app 👋
+# AI×夢スケッチ日記帳
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+このアプリは夢を記録し、AIが画像を生成してくれる日記アプリのサンプルです。iOSらしいシンプルなUIと多言語対応を備えています。
+
+## 主な機能
+
+- 夢のテキスト記録
+- 多言語切り替え（日本語／英語）
+- テーマカラーはミスティックパープルとパステルグリーンを基調
 
 ## Get started
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="record"
+        options={{
+          title: 'Record',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="pencil" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/record.tsx
+++ b/app/(tabs)/record.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { StyleSheet, TextInput, Alert, View } from 'react-native';
+import { ThemedView } from '@/components/ThemedView';
+import { GradientButton } from '@/components/GradientButton';
+import { useLocalization } from '@/contexts/LocalizationContext';
+
+export default function RecordScreen() {
+  const { t, language, setLanguage } = useLocalization();
+  const [dream, setDream] = useState('');
+
+  const onSave = () => {
+    Alert.alert(t('save'), dream || t('dreamPlaceholder'));
+    setDream('');
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.row}>
+        <GradientButton
+          title={language === 'en' ? '日本語' : 'English'}
+          onPress={() => setLanguage(language === 'en' ? 'ja' : 'en')}
+        />
+      </View>
+      <TextInput
+        style={styles.input}
+        value={dream}
+        onChangeText={setDream}
+        placeholder={t('dreamPlaceholder')}
+        multiline
+      />
+      <GradientButton title={t('save')} onPress={onSave} style={styles.button} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    gap: 12,
+  },
+  input: {
+    flex: 1,
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    textAlignVertical: 'top',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  button: {
+    alignSelf: 'flex-end',
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { LocalizationProvider } from '@/contexts/LocalizationContext';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -18,12 +19,14 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <LocalizationProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </LocalizationProvider>
   );
 }

--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+interface Props {
+  title: string;
+  onPress: () => void;
+  style?: ViewStyle;
+}
+
+export function GradientButton({ title, onPress, style }: Props) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const start = Colors[colorScheme].buttonStart;
+  const end = Colors[colorScheme].buttonEnd;
+
+  return (
+    <Pressable onPress={onPress} style={style} accessibilityRole="button">
+      <LinearGradient colors={[start, end]} style={styles.button}>
+        <Text style={styles.text}>{title}</Text>
+      </LinearGradient>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  text: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,22 +3,26 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+const tintColorLight = '#C8A2C8';
+const tintColorDark = '#C8A2C8';
 
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
+    text: '#2E2E3A',
+    background: '#F5F5FA',
     tint: tintColorLight,
+    buttonStart: '#A8E6CF',
+    buttonEnd: '#C8A2C8',
     icon: '#687076',
     tabIconDefault: '#687076',
     tabIconSelected: tintColorLight,
   },
   dark: {
-    text: '#ECEDEE',
-    background: '#151718',
+    text: '#E0E0E0',
+    background: '#1a1f36',
     tint: tintColorDark,
+    buttonStart: '#2C2F49',
+    buttonEnd: '#C8A2C8',
     icon: '#9BA1A6',
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,

--- a/constants/translations.ts
+++ b/constants/translations.ts
@@ -1,0 +1,15 @@
+export const translations = {
+  en: {
+    recordDream: 'Record Dream',
+    save: 'Save',
+    dreamPlaceholder: 'Describe your dream...'
+  },
+  ja: {
+    recordDream: '夢を記録',
+    save: '保存',
+    dreamPlaceholder: '夢の内容を入力...'
+  },
+};
+
+export type TranslationKey = keyof typeof translations.en;
+export type SupportedLanguage = keyof typeof translations;

--- a/contexts/LocalizationContext.tsx
+++ b/contexts/LocalizationContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { translations, SupportedLanguage, TranslationKey } from '@/constants/translations';
+
+interface LocalizationContextValue {
+  language: SupportedLanguage;
+  setLanguage: (lng: SupportedLanguage) => void;
+  t: (key: TranslationKey) => string;
+}
+
+const LocalizationContext = createContext<LocalizationContextValue | undefined>(undefined);
+
+export function LocalizationProvider({ children }: { children: ReactNode }) {
+  const deviceLocale = Intl.DateTimeFormat().resolvedOptions().locale;
+  const initial = deviceLocale.startsWith('ja') ? 'ja' : 'en';
+  const [language, setLanguage] = useState<SupportedLanguage>(initial);
+
+  const t = (key: TranslationKey) => translations[language][key] || key;
+
+  return (
+    <LocalizationContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LocalizationContext.Provider>
+  );
+}
+
+export function useLocalization() {
+  const context = useContext(LocalizationContext);
+  if (!context) {
+    throw new Error('useLocalization must be used within LocalizationProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- implement custom color scheme
- add translations and localization context
- create gradient button component
- add dream recording screen with language toggle
- document features in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684946a49824832680c37627dd318fa6