### PR TITLE
Add diary list and settings tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# Welcome to your Expo app 👋
+# AI×夢スケッチ日記帳
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+このアプリは夢を記録し、AIが画像を生成してくれる日記アプリのサンプルです。iOSらしいシンプルなUIと多言語対応を備えています。
+
+## 主な機能
+
+- 夢のテキスト記録
+- 多言語切り替え（日本語／英語）
+- テーマカラーはミスティックパープルとパステルグリーンを基調
+- 日記一覧画面と追加画面
+- 言語とテーマを変更できる設定画面
 
 ## Get started
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -7,9 +7,11 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useLocalization } from '@/contexts/LocalizationContext';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const { t } = useLocalization();
 
   return (
     <Tabs
@@ -27,17 +29,24 @@ export default function TabLayout() {
         }),
       }}>
       <Tabs.Screen
-        name="index"
+        name="diary"
         options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          title: t('diary'),
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="book.closed.fill" color={color} />,
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="record"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          title: t('addEntry'),
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="plus.circle.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: t('settings'),
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="gearshape.fill" color={color} />,
         }}
       />
     </Tabs>

--- a/app/(tabs)/diary.tsx
+++ b/app/(tabs)/diary.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { FlatList, StyleSheet, Pressable } from 'react-native';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { useLocalization } from '@/contexts/LocalizationContext';
+
+interface Entry {
+  id: string;
+  text: string;
+}
+
+export default function DiaryScreen() {
+  const { t } = useLocalization();
+  const [entries] = useState<Entry[]>([
+    { id: '1', text: 'I was flying over a city filled with lights.' },
+    { id: '2', text: 'A gentle river flowed backwards in time.' },
+  ]);
+
+  return (
+    <ThemedView style={styles.container}>
+      <FlatList
+        data={entries}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Pressable style={styles.card}>
+            <ThemedText style={styles.text}>{item.text}</ThemedText>
+          </Pressable>
+        )}
+        ItemSeparatorComponent={() => <ThemedView style={styles.separator} />}
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  card: {
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+  },
+  text: {
+    fontSize: 16,
+  },
+  separator: {
+    height: 12,
+  },
+});

--- a/app/(tabs)/record.tsx
+++ b/app/(tabs)/record.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { StyleSheet, TextInput, Alert, View } from 'react-native';
+import { ThemedView } from '@/components/ThemedView';
+import { GradientButton } from '@/components/GradientButton';
+import { useLocalization } from '@/contexts/LocalizationContext';
+
+export default function RecordScreen() {
+  const { t, language, setLanguage } = useLocalization();
+  const [dream, setDream] = useState('');
+
+  const onSave = () => {
+    Alert.alert(t('save'), dream || t('dreamPlaceholder'));
+    setDream('');
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <View style={styles.row}>
+        <GradientButton
+          title={language === 'en' ? '日本語' : 'English'}
+          onPress={() => setLanguage(language === 'en' ? 'ja' : 'en')}
+        />
+      </View>
+      <TextInput
+        style={styles.input}
+        value={dream}
+        onChangeText={setDream}
+        placeholder={t('dreamPlaceholder')}
+        multiline
+      />
+      <GradientButton title={t('save')} onPress={onSave} style={styles.button} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    gap: 12,
+  },
+  input: {
+    flex: 1,
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    textAlignVertical: 'top',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  button: {
+    alignSelf: 'flex-end',
+  },
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { StyleSheet, View, Pressable } from 'react-native';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { useLocalization } from '@/contexts/LocalizationContext';
+import { useThemeMode, ThemeMode } from '@/contexts/ThemeContext';
+
+export default function SettingsScreen() {
+  const { language, setLanguage, t } = useLocalization();
+  const { mode, setMode } = useThemeMode();
+
+  const ThemeOption = ({ value, label }: { value: ThemeMode; label: string }) => (
+    <Pressable style={styles.row} onPress={() => setMode(value)}>
+      <ThemedText style={styles.optionText}>
+        {label} {mode === value ? '✓' : ''}
+      </ThemedText>
+    </Pressable>
+  );
+
+  const LangOption = ({ value, label }: { value: 'en' | 'ja'; label: string }) => (
+    <Pressable style={styles.row} onPress={() => setLanguage(value)}>
+      <ThemedText style={styles.optionText}>
+        {label} {language === value ? '✓' : ''}
+      </ThemedText>
+    </Pressable>
+  );
+
+  return (
+    <ThemedView style={styles.container}>
+      <ThemedText type="subtitle" style={styles.sectionTitle}>
+        {t('language')}
+      </ThemedText>
+      <View style={styles.section}>
+        <LangOption value="en" label="English" />
+        <LangOption value="ja" label="日本語" />
+      </View>
+      <ThemedText type="subtitle" style={styles.sectionTitle}>
+        {t('theme')}
+      </ThemedText>
+      <View style={styles.section}>
+        <ThemeOption value="system" label={t('system')} />
+        <ThemeOption value="light" label={t('light')} />
+        <ThemeOption value="dark" label={t('dark')} />
+      </View>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  sectionTitle: {
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  section: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  row: {
+    padding: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ccc',
+  },
+  optionText: {
+    fontSize: 16,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,8 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { LocalizationProvider } from '@/contexts/LocalizationContext';
+import { ThemeModeProvider } from '@/contexts/ThemeContext';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -18,12 +20,16 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <LocalizationProvider>
+      <ThemeModeProvider>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </ThemeModeProvider>
+    </LocalizationProvider>
   );
 }

--- a/components/GradientButton.tsx
+++ b/components/GradientButton.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet, ViewStyle } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+interface Props {
+  title: string;
+  onPress: () => void;
+  style?: ViewStyle;
+}
+
+export function GradientButton({ title, onPress, style }: Props) {
+  const colorScheme = useColorScheme() ?? 'light';
+  const start = Colors[colorScheme].buttonStart;
+  const end = Colors[colorScheme].buttonEnd;
+
+  return (
+    <Pressable onPress={onPress} style={style} accessibilityRole="button">
+      <LinearGradient colors={[start, end]} style={styles.button}>
+        <Text style={styles.text}>{title}</Text>
+      </LinearGradient>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  text: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,9 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'book.closed.fill': 'book',
+  'plus.circle.fill': 'add-circle',
+  'gearshape.fill': 'settings',
 } as IconMapping;
 
 /**

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,22 +3,26 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+const tintColorLight = '#C8A2C8';
+const tintColorDark = '#C8A2C8';
 
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
+    text: '#2E2E3A',
+    background: '#F5F5FA',
     tint: tintColorLight,
+    buttonStart: '#A8E6CF',
+    buttonEnd: '#C8A2C8',
     icon: '#687076',
     tabIconDefault: '#687076',
     tabIconSelected: tintColorLight,
   },
   dark: {
-    text: '#ECEDEE',
-    background: '#151718',
+    text: '#E0E0E0',
+    background: '#1a1f36',
     tint: tintColorDark,
+    buttonStart: '#2C2F49',
+    buttonEnd: '#C8A2C8',
     icon: '#9BA1A6',
     tabIconDefault: '#9BA1A6',
     tabIconSelected: tintColorDark,

--- a/constants/translations.ts
+++ b/constants/translations.ts
@@ -1,0 +1,31 @@
+export const translations = {
+  en: {
+    recordDream: 'Record Dream',
+    save: 'Save',
+    dreamPlaceholder: 'Describe your dream...',
+    diary: 'Diary',
+    settings: 'Settings',
+    language: 'Language',
+    theme: 'Theme',
+    system: 'System',
+    light: 'Light',
+    dark: 'Dark',
+    addEntry: 'Add Entry'
+  },
+  ja: {
+    recordDream: '夢を記録',
+    save: '保存',
+    dreamPlaceholder: '夢の内容を入力...',
+    diary: '日記',
+    settings: '設定',
+    language: '言語',
+    theme: 'テーマ',
+    system: 'システムに従う',
+    light: 'ライト',
+    dark: 'ダーク',
+    addEntry: '追加'
+  },
+};
+
+export type TranslationKey = keyof typeof translations.en;
+export type SupportedLanguage = keyof typeof translations;

--- a/contexts/LocalizationContext.tsx
+++ b/contexts/LocalizationContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { translations, SupportedLanguage, TranslationKey } from '@/constants/translations';
+
+interface LocalizationContextValue {
+  language: SupportedLanguage;
+  setLanguage: (lng: SupportedLanguage) => void;
+  t: (key: TranslationKey) => string;
+}
+
+const LocalizationContext = createContext<LocalizationContextValue | undefined>(undefined);
+
+export function LocalizationProvider({ children }: { children: ReactNode }) {
+  const deviceLocale = Intl.DateTimeFormat().resolvedOptions().locale;
+  const initial = deviceLocale.startsWith('ja') ? 'ja' : 'en';
+  const [language, setLanguage] = useState<SupportedLanguage>(initial);
+
+  const t = (key: TranslationKey) => translations[language][key] || key;
+
+  return (
+    <LocalizationContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LocalizationContext.Provider>
+  );
+}
+
+export function useLocalization() {
+  const context = useContext(LocalizationContext);
+  if (!context) {
+    throw new Error('useLocalization must be used within LocalizationProvider');
+  }
+  return context;
+}

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { Appearance, ColorSchemeName } from 'react-native';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  setMode: (mode: ThemeMode) => void;
+  colorScheme: NonNullable<ColorSchemeName>;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeModeProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<ThemeMode>('system');
+  const systemScheme = Appearance.getColorScheme() ?? 'light';
+  const colorScheme = mode === 'system' ? systemScheme : mode;
+
+  return (
+    <ThemeContext.Provider value={{ mode, setMode, colorScheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useThemeMode() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useThemeMode must be used within ThemeModeProvider');
+  return ctx;
+}

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,1 +1,8 @@
-export { useColorScheme } from 'react-native';
+import { useColorScheme as useSystemColorScheme } from 'react-native';
+import { useThemeMode } from '@/contexts/ThemeContext';
+
+export function useColorScheme() {
+  const system = useSystemColorScheme();
+  const { colorScheme } = useThemeMode();
+  return colorScheme ?? system ?? 'light';
+}

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useColorScheme as useRNColorScheme } from 'react-native';
+import { useThemeMode } from '@/contexts/ThemeContext';
 
 /**
  * To support static rendering, this value needs to be re-calculated on the client side for web
@@ -11,10 +12,13 @@ export function useColorScheme() {
     setHasHydrated(true);
   }, []);
 
-  const colorScheme = useRNColorScheme();
+  const system = useRNColorScheme();
+  const { colorScheme } = useThemeMode();
+
+  const scheme = colorScheme ?? system ?? 'light';
 
   if (hasHydrated) {
-    return colorScheme;
+    return scheme;
   }
 
   return 'light';


### PR DESCRIPTION
## Summary
- implement diary list screen and settings screen
- manage theme with ThemeContext
- update bottom tabs with icons and translations
- enhance color scheme hook to respect theme setting
- update README with new features

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684946a49824832680c37627dd318fa6