### PR TITLE
Fix ThemePreferenceProvider usage

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,7 +8,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { LocalizationProvider } from '@/contexts/LocalizationContext';
 import { ThemePreferenceProvider } from '@/contexts/ThemeContext';
 
-export default function RootLayout() {
+function RootLayoutNav() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
@@ -20,15 +20,21 @@ export default function RootLayout() {
   }
 
   return (
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="+not-found" />
+      </Stack>
+      <StatusBar style="auto" />
+    </ThemeProvider>
+  );
+}
+
+export default function RootLayout() {
+  return (
     <LocalizationProvider>
       <ThemePreferenceProvider>
-        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-          <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen name="+not-found" />
-          </Stack>
-          <StatusBar style="auto" />
-        </ThemeProvider>
+        <RootLayoutNav />
       </ThemePreferenceProvider>
     </LocalizationProvider>
   );


### PR DESCRIPTION
## Summary
- wrap color scheme logic in a separate component so it is inside `ThemePreferenceProvider`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684957bd52408326a89a1f7cdb8c4347